### PR TITLE
(#27) Escape PackageProperties elements

### DIFF
--- a/src/Core/Authoring/PackageBuilder.cs
+++ b/src/Core/Authoring/PackageBuilder.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.IO;
 using System.IO.Packaging;
 using System.Linq;
+using System.Security;
 using NuGet.Resources;
 
 namespace NuGet
@@ -302,14 +303,14 @@ namespace NuGet
                 WriteFiles(package);
 
                 // Copy the metadata properties back to the package
-                package.PackageProperties.Creator = String.Join(",", Authors);
-                package.PackageProperties.Description = Description;
+                package.PackageProperties.Creator = SecurityElement.Escape(String.Join(",", Authors));
+                package.PackageProperties.Description = SecurityElement.Escape(Description);
                 package.PackageProperties.Identifier = Id;
                 package.PackageProperties.Version = Version.ToString();
-                package.PackageProperties.Language = Language;
-                package.PackageProperties.Keywords = ((IPackageMetadata)this).Tags;
-                package.PackageProperties.Title = Title;
-                package.PackageProperties.LastModifiedBy = CreatorInfo();
+                package.PackageProperties.Language = SecurityElement.Escape(Language);
+                package.PackageProperties.Keywords = SecurityElement.Escape(((IPackageMetadata)this).Tags);
+                package.PackageProperties.Title = SecurityElement.Escape(Title);
+                package.PackageProperties.LastModifiedBy = SecurityElement.Escape(CreatorInfo());
             }
         }
 


### PR DESCRIPTION
On .Net fx, the PackageProperties elements have xml special chars
escaped. On Mono, they do not get escaped. mono/mono#21227

In the process of reading the nuspec metadata, escaped chars like "&lt;"
get converted back into what they represent, for example "<". This is
not an issue on Windows, but is it an issue on Mono.

This manually escapes xml special chars from the PackageProperties
strings. The id and version are not escaped, as they cannot contain xml
special chars in the first place.

Fixes #27 


How this PR was tested:
1. Clone this repository on both a windows system and a linux system: https://github.com/Starz0r/ChocolateyPackagingScripts/tree/master/src/templates/dust
2. Build the `dust` package on both to validate that it will build on windows and fail on linux
3. Build and strongname nuget-chocolatey
4. Drop the dll and pdb into the choco source code tree on windows and build choco
5. Pack the `dust` package on windows with the artifact from the previous step to validate that it still works.
6. Drop the dll and pdb into the choco source code tree on linux and build choco
7. Pack the `dust` package on linux with the artifact from the previous step to validate that this pr fixes the issue on Linux
8. Add a `&lt;` to each of the `title`, `authors`,  and `tags` elements in the `dust.nuspec` on the Linux system
9. Run the pack again to validate that the escaping of the other elements works.