### PR TITLE
(#31) Enable running tests in Visual Studio

### DIFF
--- a/Build/NuGet.Test.targets
+++ b/Build/NuGet.Test.targets
@@ -1,16 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 <UsingTask AssemblyFile="$(NuGetRoot)\Tools\XUnit\xunit.runner.msbuild.dll" TaskName="Xunit.Runner.MSBuild.xunit" />
 <Target Name="RunTests">
-	<ItemGroup>
-		<Line Include="&lt;configuration&gt;&lt;appSettings&gt;
-&lt;add key=&quot;TargetDir&quot; value=&quot;$(TargetDir)&quot;/&gt;
-&lt;/appSettings&gt;&lt;/configuration&gt;" />
-		</ItemGroup>
-	<WriteLinesToFile
-		File="$(TargetDir)$(AssemblyName).dll.config"
-		Lines="@(Line)"			
-		Overwrite="true"
-		/> 
     <xunit Assembly="$(TargetDir)$(AssemblyName).dll" />
 </Target>
 </Project>

--- a/test/CommandLine.Test/CommandLine.Test.csproj
+++ b/test/CommandLine.Test/CommandLine.Test.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\..\Build\NuGet.Settings.targets" />
   <PropertyGroup>
     <ProjectGuid>{5376E601-D111-4198-8BC2-F1118433CC83}</ProjectGuid>
@@ -7,6 +8,8 @@
     <RootNamespace>NuGet.Test</RootNamespace>
     <AssemblyName>NuGet.Test</AssemblyName>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Build" />
@@ -114,4 +117,10 @@
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\Build\NuGet.Test.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
 </Project>

--- a/test/CommandLine.Test/packages.config
+++ b/test/CommandLine.Test/packages.config
@@ -4,4 +4,5 @@
   <package id="Ninject" version="2.2.1.4" />
   <package id="xunit" version="1.9.2" targetFramework="net40" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net40" />
+  <package id="xunit.runner.visualstudio" version="2.4.1" targetFramework="net40" developmentDependency="true" />
 </packages>

--- a/test/Core.Test/Core.Test.csproj
+++ b/test/Core.Test/Core.Test.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\..\Build\NuGet.Settings.targets" />
   <PropertyGroup>
     <ProjectGuid>{D3106412-E3AF-4CB6-B6D3-3664465B491F}</ProjectGuid>
@@ -7,6 +8,8 @@
     <RootNamespace>NuGet.Test</RootNamespace>
     <AssemblyName>NuGet.Test</AssemblyName>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
@@ -35,11 +38,9 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="WindowsBase" />
     <Reference Include="xunit, Version=1.9.2.1705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>
     <Reference Include="xunit.extensions, Version=1.9.2.1705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\xunit.extensions.1.9.2\lib\net20\xunit.extensions.dll</HintPath>
     </Reference>
   </ItemGroup>
@@ -153,4 +154,10 @@
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\Build\NuGet.Test.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
 </Project>

--- a/test/Core.Test/packages.config
+++ b/test/Core.Test/packages.config
@@ -4,4 +4,5 @@
   <package id="Ninject" version="2.2.1.4" />
   <package id="xunit" version="1.9.2" targetFramework="net40" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net40" />
+  <package id="xunit.runner.visualstudio" version="2.4.1" targetFramework="net40" developmentDependency="true" />
 </packages>

--- a/test/Server.Test/Server.Test.csproj
+++ b/test/Server.Test/Server.Test.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\..\Build\NuGet.Settings.targets" />
   <PropertyGroup>
     <ProjectGuid>{92D18050-3867-4E39-B305-9F9870F66F5E}</ProjectGuid>
@@ -8,6 +9,8 @@
     <RootNamespace>Server.Test</RootNamespace>
     <AssemblyName>Server.Test</AssemblyName>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Moq, Version=4.1.1309.919, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
@@ -65,4 +68,10 @@
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\Build\NuGet.Test.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
 </Project>

--- a/test/Server.Test/packages.config
+++ b/test/Server.Test/packages.config
@@ -3,4 +3,5 @@
   <package id="Moq" version="4.1.1309.0919" targetFramework="net40" />
   <package id="xunit" version="1.9.2" targetFramework="net40" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net40" />
+  <package id="xunit.runner.visualstudio" version="2.4.1" targetFramework="net40" developmentDependency="true" />
 </packages>

--- a/test/Test.Integration/Test.Integration.csproj
+++ b/test/Test.Integration/Test.Integration.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\..\Build\NuGet.Settings.targets" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -14,6 +15,8 @@
     <AssemblyName>NuGet.Test.Integration</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Moq, Version=4.1.1309.919, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
@@ -101,4 +104,22 @@
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\Build\NuGet.Test.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
+  <Target Name="AfterBuild">
+    <ItemGroup>
+		<Line Include="&lt;configuration&gt;&lt;appSettings&gt;
+&lt;add key=&quot;TargetDir&quot; value=&quot;$(TargetDir)&quot;/&gt;
+&lt;/appSettings&gt;&lt;/configuration&gt;" />
+		</ItemGroup>
+        <WriteLinesToFile
+            File="$(TargetDir)$(AssemblyName).dll.config"
+            Lines="@(Line)"			
+            Overwrite="true"
+            /> 
+    </Target>
 </Project>

--- a/test/Test.Integration/packages.config
+++ b/test/Test.Integration/packages.config
@@ -3,4 +3,5 @@
   <package id="Moq" version="4.1.1309.0919" targetFramework="net40" />
   <package id="xunit" version="1.9.2" targetFramework="net40" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net40" />
+  <package id="xunit.runner.visualstudio" version="2.4.1" targetFramework="net40" developmentDependency="true" />
 </packages>

--- a/test/Test.Utility/Test.Utility.csproj
+++ b/test/Test.Utility/Test.Utility.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\..\Build\NuGet.Settings.targets" />
   <PropertyGroup>
     <ProjectGuid>{F016882A-C798-4446-BB75-D3C393A38B32}</ProjectGuid>
@@ -7,6 +8,8 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NuGet.Test.Utility</RootNamespace>
     <AssemblyName>NuGet.Test.Utility</AssemblyName>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\..\Common\CommonAssemblyInfo.cs">
@@ -60,6 +63,12 @@
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/Test.Utility/packages.config
+++ b/test/Test.Utility/packages.config
@@ -3,4 +3,5 @@
   <package id="Moq" version="4.1.1309.0919" targetFramework="net40" />
   <package id="xunit" version="1.9.2" targetFramework="net40" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net40" />
+  <package id="xunit.runner.visualstudio" version="2.4.1" targetFramework="net40" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
## Description Of Changes

This adds the VisualStudio xunit runner to allow running tests from the
test explorer. Version 2.4.1 is the last version that works with .net 4.0

Additionally, an after build target is moved from the separate testing target file to the integration test .csproj to ensure the required .config file is created before running integration tests.

## Motivation and Context

See #31

## Testing

Opened `NuGet.Commandline.Sln` in Visual Studio 2022, and ran the tests from test explorer.
Ran `.\build.cmd`

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #31

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
